### PR TITLE
OPS-0 Adding negated property as variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ module "waf_acl_rules" {
       name     = "allowheaderx"
       priority = "3"
       enabled  = true
+      negated  = false
       ranges   = []
       byte_match_tuples = [{
         field_to_match_data = "header-X",

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ module "waf_acl_rules" {
     name              = "name"
     priority          = "1"
     enabled           = false
+    negated           = false
     byte_match_tuples = []
     ranges = [
       {
@@ -31,6 +32,7 @@ module "waf_acl_rules" {
     name              = "blockgoogle"
     priority          = "2"
     enabled           = true
+    negated           = true
     byte_match_tuples = []
     ranges = [
       {

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -7,6 +7,7 @@ locals {
     {
       name              = "name"
       priority          = "1"
+      negated           = false
       enabled           = false
       byte_match_tuples = []
       uri_match = []
@@ -18,6 +19,7 @@ locals {
     }, {
       name              = "blockgoogle"
       priority          = "2"
+      negated           = false
       enabled           = true
       byte_match_tuples = []
       uri_match = []
@@ -32,6 +34,7 @@ locals {
     }, {
       name     = "allowheaderx"
       priority = "3"
+      negated  = false
       enabled  = true
       ranges   = []
       uri_match = []
@@ -44,6 +47,7 @@ locals {
     }, {
       name     = "allowPathWithToken"
       priority = "4"
+      negated  = false
       enabled  = true
       ranges   = []
       uri_match = [

--- a/main.tf
+++ b/main.tf
@@ -61,7 +61,7 @@ resource "aws_waf_rule" "this" {
     for_each = (length(each.value.ranges) > 0 ? [true] : [])
     content {
       data_id = aws_waf_ipset.this[each.key].id
-      negated = lookup(each.value, "negated", false)
+      negated = each.value["negated"]
       type    = "IPMatch"
     }
   }
@@ -71,7 +71,7 @@ resource "aws_waf_rule" "this" {
     for_each = (length(each.value.byte_match_tuples) > 0 ? [true] : [])
     content {
       data_id = aws_waf_byte_match_set.this[each.key].id
-      negated = lookup(each.value, "negated", false)
+      negated = each.value["negated"]
       type    = "ByteMatch"
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -61,7 +61,7 @@ resource "aws_waf_rule" "this" {
     for_each = (length(each.value.ranges) > 0 ? [true] : [])
     content {
       data_id = aws_waf_ipset.this[each.key].id
-      negated = each.value["negated"]
+      negated = lookup(each.value, "negated", false)
       type    = "IPMatch"
     }
   }
@@ -71,7 +71,7 @@ resource "aws_waf_rule" "this" {
     for_each = (length(each.value.byte_match_tuples) > 0 ? [true] : [])
     content {
       data_id = aws_waf_byte_match_set.this[each.key].id
-      negated = each.value["negated"]
+      negated = lookup(each.value, "negated", false)
       type    = "ByteMatch"
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -61,7 +61,7 @@ resource "aws_waf_rule" "this" {
     for_each = (length(each.value.ranges) > 0 ? [true] : [])
     content {
       data_id = aws_waf_ipset.this[each.key].id
-      negated = false
+      negated = each.value["negated"]
       type    = "IPMatch"
     }
   }
@@ -71,7 +71,7 @@ resource "aws_waf_rule" "this" {
     for_each = (length(each.value.byte_match_tuples) > 0 ? [true] : [])
     content {
       data_id = aws_waf_byte_match_set.this[each.key].id
-      negated = false
+      negated = each.value["negated"]
       type    = "ByteMatch"
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -5,7 +5,7 @@ variable "waf_rules" {
     name              = string
     enabled           = bool
     priority          = string
-    negated            = bool
+    negated           = bool
     ranges            = list(map(string))
     byte_match_tuples = list(map(string))
     uri_match         = list(map(string))

--- a/variables.tf
+++ b/variables.tf
@@ -5,6 +5,7 @@ variable "waf_rules" {
     name              = string
     enabled           = bool
     priority          = string
+    negated            = bool
     ranges            = list(map(string))
     byte_match_tuples = list(map(string))
     uri_match         = list(map(string))


### PR DESCRIPTION
# Adding negated as variable in predicate

## Description
Enable the possibility to modify the `negated` property under the predicates, currently its always set to `false`

## Why is needed
To be able to add waf rules that requires an expression to be negated, for example deny all requests that don't contain a User-Agent header

> [negated](https://www.terraform.io/docs/providers/aws/r/waf_rule.html#negated) - (Required) Set this to false if you want to allow, block, or count requests based on the settings in the specified waf_byte_match_set, waf_ipset, aws_waf_size_constraint_set, aws_waf_sql_injection_match_set or aws_waf_xss_match_set. For example, if an IPSet includes the IP address 192.0.2.44, AWS WAF will allow or block requests based on that IP address. If set to true, AWS WAF will allow, block, or count requests based on all IP addresses except 192.0.2.44.

## What was added
New property added into the waf_rules variable definition:

`negated            = bool`

In main.tf in the dynamic predicates

`negated = each.value["negated"]`

