### PR TITLE
OPS-0 Enabling action type per rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ module "waf_acl_rules" {
     priority          = "1"
     enabled           = false
     negated           = false
+    action_type       = "ALLOW"
     byte_match_tuples = []
     ranges = [
       {
@@ -33,6 +34,7 @@ module "waf_acl_rules" {
     priority          = "2"
     enabled           = true
     negated           = true
+    action_type       = "BLOCK"
     byte_match_tuples = []
     ranges = [
       {

--- a/README.md
+++ b/README.md
@@ -46,11 +46,12 @@ module "waf_acl_rules" {
     ]
     }
     , {
-      name     = "allowheaderx"
-      priority = "3"
-      enabled  = true
-      negated  = false
-      ranges   = []
+      name         = "allowheaderx"
+      priority     = "3"
+      enabled      = true
+      negated      = false
+      action_type  = "ALLOW"
+      ranges       = []
       byte_match_tuples = [{
         field_to_match_data = "header-X",
         target_string       = "containsthis"

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -9,6 +9,7 @@ locals {
       priority          = "1"
       negated           = false
       enabled           = false
+      action_type       = "ALLOW"
       byte_match_tuples = []
       uri_match = []
       ranges = [
@@ -21,6 +22,7 @@ locals {
       priority          = "2"
       negated           = false
       enabled           = true
+      action_type       = "ALLOW"
       byte_match_tuples = []
       uri_match = []
       ranges = [
@@ -32,12 +34,13 @@ locals {
         },
       ]
     }, {
-      name     = "allowheaderx"
-      priority = "3"
-      negated  = false
-      enabled  = true
-      ranges   = []
-      uri_match = []
+      name         = "allowheaderx"
+      priority     = "3"
+      negated      = false
+      enabled      = true
+      action_type  = "ALLOW"
+      ranges       = []
+      uri_match    = []
       byte_match_tuples = [
         {
           field_to_match_data = "header-X",
@@ -45,11 +48,12 @@ locals {
         },
       ]
     }, {
-      name     = "allowPathWithToken"
-      priority = "4"
-      negated  = false
-      enabled  = true
-      ranges   = []
+      name         = "allowPathWithToken"
+      priority     = "4"
+      negated      = false
+      enabled      = true
+      action_type  = "ALLOW"
+      ranges       = []
       uri_match = [
         {
           target_string = "/your/uri/"

--- a/variables.tf
+++ b/variables.tf
@@ -6,6 +6,7 @@ variable "waf_rules" {
     enabled           = bool
     priority          = string
     negated           = bool
+    action_type       = string
     ranges            = list(map(string))
     byte_match_tuples = list(map(string))
     uri_match         = list(map(string))


### PR DESCRIPTION
# Adding action_type as variable in web rule definition

## Description
Enable the possibility to add the action_type per rule and not only using the default action, this property its not mandatory so in case that is not specified, it will assume ALLOW as default.

## Why is needed
To be able to add waf rules that requires a different action than the default

> [action](https://www.terraform.io/docs/providers/aws/r/waf_web_acl.html#action) (Optional) The action that CloudFront or AWS WAF takes when a web request matches the conditions in the rule. Not used if type is GROUP.
type - (Required) valid values are: BLOCK, ALLOW, or COUNT

## What was added
New property added into the waf_rules variable definition:

`action_type            = string`

## Example 

```
~ resource "aws_waf_web_acl" "this" {
        arn         = "arn:aws:waf::xxxxxxxxxx:webacl/xxxxxxxxxxxxxxxxxx"
        id          = "xxxxxxxxxxxxxxxxxx"
        metric_name = "waf"
        name        = "waf"
        tags        = {}

        default_action {
            type = "ALLOW"
        }

      + rules {
          + priority = 1
          + rule_id  = (known after apply)
          + type     = "REGULAR"

          + action {
              + type = "BLOCK"
            }
        }
    }
```